### PR TITLE
Fixes #52

### DIFF
--- a/GPyOpt/util/general.py
+++ b/GPyOpt/util/general.py
@@ -134,7 +134,7 @@ def get_quantiles(acquisition_par, fmin, m, s):
         s[s<1e-10] = 1e-10
     elif s< 1e-10:
         s = 1e-10
-    u = (fmin-m+acquisition_par)/s
+    u = (fmin-m-acquisition_par)/s
     phi = np.exp(-0.5 * u**2) / np.sqrt(2*np.pi)
     Phi = 0.5 * erfc(-u / np.sqrt(2))
     return (phi, Phi, u)


### PR DESCRIPTION
The current implementation calculates:
\Phi\left(\frac{f(x^+) - \mu(x) + \Psi}{\sigma(x)} \right) \\
= P(f(x) \leq f(x^+) + \Psi) \\
= P(f(x) - \Psi \leq f(x^+))

Where Psi is the jitter term.

This commit fixes it so that it correctly calculates P(f(x) + \Psi \leq f(x^+))

Unfortunately, since #50 is not merged yet the tests are failing on master.