### PR TITLE
fix ValueError

### DIFF
--- a/GPyOpt/core/bo.py
+++ b/GPyOpt/core/bo.py
@@ -206,7 +206,7 @@ class BO(object):
                 self.acquisition_optimizer.pulled_arms = self.X
 
     def _save_model_parameter_values(self):
-        if self.model_parameters_iterations == None:
+        if self.model_parameters_iterations is None:
             self.model_parameters_iterations = self.model.get_model_parameters()
         else:
             self.model_parameters_iterations = np.vstack((self.model_parameters_iterations,self.model.get_model_parameters()))


### PR DESCRIPTION
With numpy 1.13.0, the comparison of self.model_parameters_iterations with None gives an error:

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

Replacing with 'is None' does the job here, although I did not check if the same problem could appear elsewhere. 

Best,