### PR TITLE
Fix bad comparison against None using ==

### DIFF
--- a/GPyOpt/core/bo.py
+++ b/GPyOpt/core/bo.py
@@ -206,7 +206,7 @@ class BO(object):
                 self.acquisition_optimizer.pulled_arms = self.X
 
     def _save_model_parameter_values(self):
-        if self.model_parameters_iterations == None:
+        if self.model_parameters_iterations is None:
             self.model_parameters_iterations = self.model.get_model_parameters()
         else:
             self.model_parameters_iterations = np.vstack((self.model_parameters_iterations,self.model.get_model_parameters()))


### PR DESCRIPTION
While running GPyOpt on python3 I started to see the following failure:

```
Traceback (most recent call last):
  File "/Users/mattlavin/Projects/GPyOpt/GPyOpt/testing/test_parallelization.py", line 102, in test_run
    unittest_result = run_eval(problem_config= self.problem_config, f_inits= self.f_inits, method_config=m_c, name=name, outpath=self.outpath, time_limit=None, unittest = self.is_unittest)
  File "/Users/mattlavin/Projects/GPyOpt/GPyOpt/testing/driver.py", line 47, in run_eval
    verbosity       = m_c['verbosity'])
  File "/Users/mattlavin/Projects/GPyOpt/GPyOpt/methods/bayesian_optimization.py", line 458, in run_optimization
    super(BayesianOptimization, self).run_optimization(max_iter = max_iter, max_time = max_time,  eps = eps, verbosity=verbosity, save_models_parameters = save_models_parameters, report_file = report_file, evaluations_file= evaluations_file, models_file=models_file)
  File "/Users/mattlavin/Projects/GPyOpt/GPyOpt/core/bo.py", line 103, in run_optimization
    self._update_model()
  File "/Users/mattlavin/Projects/GPyOpt/GPyOpt/core/bo.py", line 198, in _update_model
    self._save_model_parameter_values()
  File "/Users/mattlavin/Projects/GPyOpt/GPyOpt/core/bo.py", line 209, in _save_model_parameter_values
    if self.model_parameters_iterations == None:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

It turns out that an array was being compared against None with `==` instead of `is` switching to `is` avoided the ambiguous type coercion.