### PR TITLE
Install import

### DIFF
--- a/GPyOpt/__init__.py
+++ b/GPyOpt/__init__.py
@@ -4,17 +4,25 @@
 import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-from GPyOpt.core.task.space import Design_space
-from . import core
-from . import methods
-from . import util
-from . import plotting
-from . import interface
-from . import models
-from . import acquisitions
-from . import optimization
-from . import objective_examples 
-from . import objective_examples as fmodels
-
+try:
+    # This variable is injected in the __builtins__ by the build
+    # process. It used to enable importing subpackages of sklearn when
+    # the binaries are not built
+    __GPYOPT_SETUP__
+except NameError:
+    __GPYOPT_SETUP__ = False
 
 from .__version__ import __version__
+
+if not __GPYOPT_SETUP__:
+    from GPyOpt.core.task.space import Design_space
+    from . import core
+    from . import methods
+    from . import util
+    from . import plotting
+    from . import interface
+    from . import models
+    from . import acquisitions
+    from . import optimization
+    from . import objective_examples
+    from . import objective_examples as fmodels

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import sys
 from setuptools import setup
 
 if sys.version_info[0] < 3:
@@ -10,7 +11,7 @@ else:
     import builtins
 
 # allows detecting that an import happens during build process
-builtins.__GPYPOT_SETUP__ = True
+builtins.__GPYOPT_SETUP__ = True
 from GPyOpt.__version__ import __version__
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,22 @@
 
 import os
 from setuptools import setup
+
+if sys.version_info[0] < 3:
+    import __builtin__ as builtins
+else:
+    import builtins
+
+# allows detecting that an import happens during build process
+builtins.__GPYPOT_SETUP__ = True
 from GPyOpt.__version__ import __version__
+
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(name = 'GPyOpt',
-      version = __version__,
+      version =__version__,
       author = read('AUTHORS.txt'),
       author_email = "j.h.gonzalez@sheffield.ac.uk",
       description = ("The Bayesian Optimization Toolbox"),


### PR DESCRIPTION
You're importing GPyOpt in your ``setup.py``. If your user doesn't already have ``GPy`` installed, this will raise an error, because GPyOpt requires GPy.

You can either not import ``__version__`` in ``setup.py`` and hard-code the version here (and risk it becoming out-of-sync with ``__version__.py``), or use this fix (copied from sklearn). There is [several other solutions](https://stackoverflow.com/questions/17583443/what-is-the-correct-way-to-share-package-version-with-setup-py-and-the-package) to this somewhat common problem.

tldr; before this fix, ``pip install -e .`` raises an ``ImportError`` if ``GPy`` is not installed, with this fix it installs this dependency automatically.