### PR TITLE
Add forgotten plt.show() statement for 2d heatplot

### DIFF
--- a/GPyOpt/plotting/plots_bo.py
+++ b/GPyOpt/plotting/plots_bo.py
@@ -113,7 +113,10 @@ def plot_acquisition(bounds,input_dim,model,Xdata,Ydata,acquisition_function,sug
         plt.ylabel('X2')
         plt.title('Acquisition function')
         plt.axis((bounds[0][0],bounds[0][1],bounds[1][0],bounds[1][1]))
-        if filename!=None:savefig(filename)
+        if filename!=None:
+            savefig(filename)
+        else:
+            plt.show()
 
 
 def plot_convergence(Xdata,best_Y, filename = None):


### PR DESCRIPTION
plt.show() has been implemented for 1d plot but forgotten for 2d plot.