### PR TITLE
fix error in parallel computation

### DIFF
--- a/GPyOpt/core/task/objective.py
+++ b/GPyOpt/core/task/objective.py
@@ -3,11 +3,6 @@
 
 import time
 import numpy as np
-from ...util.general import get_d_moments
-import GPy
-import GPyOpt
-import sys
-import functools
 
 class Objective(object):
     """
@@ -76,10 +71,11 @@ class SingleObjective(Objective):
         Evaluates the function a x, where x can be a single location or a batch. The evaluation is performed in parallel
         according to the number of accessible cores.
         """
+        from sys import version_info
         # --- parallel evaluation of the function
         divided_samples = [x[i::self.n_procs] for i in range(self.n_procs)]
 
-        if sys.version_info.major < 3:
+        if version_info.major < 3:
             from multiprocess import Pool
             p = Pool(processes=self.n_procs)
             results = p.map(self._eval_func, divided_samples)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ mock>=2.0.0
 PyDOE >= 0.3.0
 sobol_seq >=0.1
 joblib>=0.11
+multiprocess>=0.70
 
 # For tests
 nose

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ six>=1.10.0
 mock>=2.0.0
 PyDOE >= 0.3.0
 sobol_seq >=0.1
+joblib>=0.11
 
 # For tests
 nose

--- a/travis_tests.py
+++ b/travis_tests.py
@@ -5,4 +5,6 @@ matplotlib.use('agg')
 import nose, warnings
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
-nose.main('GPyOpt', defaultTest='GPyOpt/testing/', argv=[''])
+
+if __name__=='__main__': # for parallel computation
+    nose.main('GPyOpt', defaultTest='GPyOpt/testing/', argv=[''])


### PR DESCRIPTION
To fix the issues #58, #60, and #65, I modified the code of objective.py by using joblib.

There was also a way to use `multiprocessing.Pool`, but the overhead at optimization seems to be large, which took about 10 to 20% more time than joblib.

I'm not familiar with parallel processing, so there may be better implementation methods. If anyone has a good idea, I'd be happy if you give me advice.

This is the alternative code I wrote with `multiprocessing.Pool`. (I did not include in this fix)
```python
    def _syncronous_batch_evaluation(self,x):
        from multiprocessing import Pool
        divided_samples = [x[i::self.n_procs] for i in range(self.n_procs)]
        p = Pool()
        results = p.map(self._eval_func, divided_samples)
        p.close()
        p.join()

        f_evals = np.vstack([res[0] for res in results])
        cost_evals = np.hstack([res[1] for res in results])

        return f_evals, cost_evals
```

Also note that those who do parallel calculations need to place the execution part of the main script within the `if __name__ == '__main__':` statement. If you do not do this, the main script will run infinitely.