### PR TITLE
Fix when only one initial date point is used

### DIFF
--- a/GPyOpt/core/bo.py
+++ b/GPyOpt/core/bo.py
@@ -134,7 +134,8 @@ class BO(object):
             except np.linalg.linalg.LinAlgError:
                 break
 
-            if not ((self.num_acquisitions < self.max_iter) and (self._distance_last_evaluations() > self.eps)):
+            if (self.num_acquisitions >= self.max_iter
+                    or (len(self.X) > 1 and self._distance_last_evaluations() <= self.eps)):
                 break
 
             self.suggested_sample = self._compute_next_evaluations()
@@ -199,15 +200,13 @@ class BO(object):
         """
         self.Y_best = best_value(self.Y)
         self.x_opt = self.X[np.argmin(self.Y),:]
-        self.fx_opt = min(self.Y)
-
+        self.fx_opt = np.min(self.Y)
 
     def _distance_last_evaluations(self):
         """
         Computes the distance between the last two evaluations.
         """
-        return np.sqrt(sum((self.X[self.X.shape[0]-1,:]-self.X[self.X.shape[0]-2,:])**2))
-
+        return np.sqrt(np.sum((self.X[-1, :] - self.X[-2, :]) ** 2))
 
     def _compute_next_evaluations(self, pending_zipped_X=None, ignored_zipped_X=None):
         """

--- a/GPyOpt/testing/methods_tests/test_bayesian_optimization.py
+++ b/GPyOpt/testing/methods_tests/test_bayesian_optimization.py
@@ -36,3 +36,12 @@ class TestBayesianOptimization(unittest.TestCase):
         x_ignored = bo_ignored.suggest_next_locations(ignored_X = x_no_ignored)
 
         self.assertFalse(np.isclose(x_ignored, x_no_ignored))
+
+    def test_one_initial_data_point(self):
+        """Make sure BO still works with only one initial data point."""
+        bounds = [{'name': 'var_1', 'type': 'continuous', 'domain': (-1, 1)}]
+        opt = BayesianOptimization(lambda x: x, bounds, initial_design_numdata=1)
+
+        # Make sure run_optimization works
+        opt.run_optimization(max_iter=1)
+        assert len(opt.Y) > 1


### PR DESCRIPTION
The current model fails silently if `initial_design_numdata=1`, because `_distance_last_evaluations()` returns 0. This fix basically makes `_distance_last_evaluations` raise an `IndexError` if one data point exists and adds an additional check for the number of data points before calling it.

