### PR TITLE
Scale maxmin normalization to [-1, 1]

### DIFF
--- a/GPyOpt/testing/util_tests/test_general_utils.py
+++ b/GPyOpt/testing/util_tests/test_general_utils.py
@@ -164,8 +164,8 @@ class TestNormalization(unittest.TestCase):
 
         y = np.array([1, 3])[:, None]
         y_norm = normalize(y, 'maxmin')
-        assert_allclose(y_norm, np.array([[0], [1]]))
+        assert_allclose(y_norm, np.array([[-1], [1]]))
 
         y = np.arange(5)
         y_norm = normalize(y - 1, 'maxmin')
-        assert_allclose(y_norm, y / 4)
+        assert_allclose(y_norm, (y - 2) / 2)

--- a/GPyOpt/util/general.py
+++ b/GPyOpt/util/general.py
@@ -226,6 +226,8 @@ def normalize(Y, normalization_type='stats'):
         y_range = np.ptp(Y)
         if y_range > 0:
             Y_norm /= y_range
+            # A range of [-1, 1] is more natural for a zero-mean GP
+            Y_norm = 2 * (Y_norm - 0.5)
     else:
         raise ValueError('Unknown normalization type: {}'.format(normalization_type))
 


### PR DESCRIPTION
Right now the `maxmin` normalization style scales the function to the interval `[0, 1]`. This PR proposes to change this to `[-1, 1]`, which is more natural for a zero-mean GP. 

@apaleyes had concerns about this change in a previous PR. But I would argue that, since `_normalize` was a private function before the previous PR, this should not affect any written code beyond empirical performance of BO. Also changing to `minmax` normalization is not exposed through the API and only possible by manually editing the `normalization_type` attribute of the `bo` object. 