### PR TITLE
initialize context and num_acquisitions

### DIFF
--- a/GPyOpt/core/bo.py
+++ b/GPyOpt/core/bo.py
@@ -49,6 +49,8 @@ class BO(object):
         self.normalization_type = 'stats' ## not added in the API
         self.de_duplication = de_duplication
         self.model_parameters_iterations = None
+        self.context = None
+        self.num_acquisitions = 0
 
     def suggest_next_locations(self, context = None, pending_X = None, ignored_X = None):
         """


### PR DESCRIPTION
Minor change that initializes `context` and `num_acquisitions` in `__init__`. Without this, the following code raises an error about missing variables.

```
import GPyOpt

def fun(x):
    return x

bounds = [{'name': 'var_1', 'type': 'continuous', 'domain': (-1,1)}]

opt = GPyOpt.methods.BayesianOptimization(fun, bounds)

opt._update_model()
opt._compute_next_evaluations()
```