### PR TITLE
correct square root in lower confidence bound acquisition

### DIFF
--- a/GPyOpt/acquisitions/LCB.py
+++ b/GPyOpt/acquisitions/LCB.py
@@ -3,6 +3,7 @@
 
 from .base import AcquisitionBase
 from ..util.general import get_quantiles
+import numpy as np
 
 class AcquisitionLCB(AcquisitionBase):
     """
@@ -33,7 +34,7 @@ class AcquisitionLCB(AcquisitionBase):
         Computes the GP-Lower Confidence Bound 
         """
         m, s = self.model.predict(x)   
-        f_acqu = -m + self.exploration_weight * s
+        f_acqu = -m + self.exploration_weight * np.sqrt(s)
         return f_acqu
 
     def _compute_acq_withGradients(self, x):
@@ -41,7 +42,7 @@ class AcquisitionLCB(AcquisitionBase):
         Computes the GP-Lower Confidence Bound and its derivative
         """
         m, s, dmdx, dsdx = self.model.predict_withGradients(x) 
-        f_acqu = -m + self.exploration_weight * s       
+        f_acqu = -m + self.exploration_weight * np.sqrt(s)       
         df_acqu = -dmdx + self.exploration_weight * dsdx
         return f_acqu, df_acqu
 


### PR DESCRIPTION
In the [original paper defining the lower confidence bound acquisition function](http://www-stat.wharton.upenn.edu/~skakade/papers/ml/bandit_GP_icml.pdf) it is defined in equation 6 as

![codecogseqn](https://user-images.githubusercontent.com/11857704/51893807-46bf5b80-23a6-11e9-80f1-6f3e141f0a43.gif)

But in GPyOpt this is computed using the variance instead of the standard deviation, producing a much tighter (wider) confidence bound than expected when the function is less (greater) than one. (The call is to `GPy.core.gp.GP.predict` which returns mean and variance. [See the doc string starting on line 299 here.](https://github.com/SheffieldML/GPy/blob/devel/GPy/core/gp.py))