### PR TITLE
Fix a broken link in the footer.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,7 @@ avatar: "/img/avatar-icon.png"
 author:
   name: Machine Learning Group - University of Sheffield.
   email: "j.h.gonzalez@sheffield.ac.uk"
-  github: https://github.com/SheffieldML    # eg. daattali
+  github: SheffieldML    # eg. daattali
  
 # Select which links to show in the footer
 footer-links-active:


### PR DESCRIPTION
I see the github link is broken and this change will point to the correct link. 
Existing Link: https://github.com/https://github.com/SheffieldML
Changed Link: https://github.com/SheffieldML