### PR TITLE
Caught mismatch between code and spec: constraints

### DIFF
--- a/GPyOpt/core/task/space.py
+++ b/GPyOpt/core/task/space.py
@@ -304,7 +304,7 @@ class Design_space(object):
             for d in self.constraints:
                 try:
                     exec('constraint = lambda x:' + d['constraint'], globals())
-                    ind_x = (constraint(x)<0)*1
+                    ind_x = (constraint(x) <= 0) * 1
                     I_x *= ind_x.reshape(x.shape[0],1)
                 except:
                     print('Fail to compile the constraint: ' + str(d))


### PR DESCRIPTION
Documentation [1] and tutorial [2] describe that satisfaction of a
constraint is "c(x) <= 0" where c(x) is a constraint. However, the
real code evaluates "c(x) < 0", which is a mismatch between code and
spec.

[1] https://gpyopt.readthedocs.io/en/latest/GPyOpt.core.task.html?highlight=constraints#module-GPyOpt.core.task.space
[2] https://nbviewer.jupyter.org/github/SheffieldML/GPyOpt/blob/master/manual/GPyOpt_constrained_optimization.ipynb