### PR TITLE
Issue #94: Fix constraint violation in anchor generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ iterate.dat
 
 docs/_build
 .pytest_cache
+
+# Virtual environments
+venv/

--- a/GPyOpt/acquisitions/base.py
+++ b/GPyOpt/acquisitions/base.py
@@ -36,7 +36,8 @@ class AcquisitionBase(object):
         """
         f_acqu = self._compute_acq(x)
         cost_x, _ = self.cost_withGradients(x)
-        return -(f_acqu*self.space.indicator_constraints(x))/cost_x
+        x_z = x if self.space.model_dimensionality == self.space.objective_dimensionality else self.space.zip_inputs(x)
+        return -(f_acqu*self.space.indicator_constraints(x_z))/cost_x
 
 
     def acquisition_function_withGradients(self, x):
@@ -47,7 +48,8 @@ class AcquisitionBase(object):
         cost_x, cost_grad_x = self.cost_withGradients(x)
         f_acq_cost = f_acqu/cost_x
         df_acq_cost = (df_acqu*cost_x - f_acqu*cost_grad_x)/(cost_x**2)
-        return -f_acq_cost*self.space.indicator_constraints(x), -df_acq_cost*self.space.indicator_constraints(x)
+        x_z = x if self.space.model_dimensionality == self.space.objective_dimensionality else self.space.zip_inputs(x)
+        return -f_acq_cost*self.space.indicator_constraints(x_z), -df_acq_cost*self.space.indicator_constraints(x_z)
 
     def optimize(self, duplicate_manager=None):
         """

--- a/GPyOpt/methods/bayesian_optimization.py
+++ b/GPyOpt/methods/bayesian_optimization.py
@@ -77,7 +77,7 @@ class BayesianOptimization(BO):
     	initial_design_numdata = 5, initial_design_type='random', acquisition_type ='EI', normalize_Y = True,
         exact_feval = False, acquisition_optimizer_type = 'lbfgs', model_update_interval=1, evaluator_type = 'sequential',
         batch_size = 1, num_cores = 1, verbosity=False, verbosity_model = False, maximize=False, de_duplication=False, **kwargs):
-
+        print('My GPyOpt repo.')
         self.modular_optimization = False
         self.initial_iter = True
         self.verbosity = verbosity

--- a/GPyOpt/methods/bayesian_optimization.py
+++ b/GPyOpt/methods/bayesian_optimization.py
@@ -77,7 +77,6 @@ class BayesianOptimization(BO):
     	initial_design_numdata = 5, initial_design_type='random', acquisition_type ='EI', normalize_Y = True,
         exact_feval = False, acquisition_optimizer_type = 'lbfgs', model_update_interval=1, evaluator_type = 'sequential',
         batch_size = 1, num_cores = 1, verbosity=False, verbosity_model = False, maximize=False, de_duplication=False, **kwargs):
-        print('My GPyOpt repo.')
         self.modular_optimization = False
         self.initial_iter = True
         self.verbosity = verbosity

--- a/GPyOpt/testing/acquisitions_tests/test_ei_acquisition.py
+++ b/GPyOpt/testing/acquisitions_tests/test_ei_acquisition.py
@@ -59,3 +59,47 @@ class TestEIAcquisition(unittest.TestCase):
         optimum_position = self.ei_acquisition.optimize()
 
         assert optimum_position == expected_optimum_position
+
+
+class TestEIAcquisitionWithCategoricalVariables(unittest.TestCase):
+	def setUp(self):
+		self.mock_model = Mock()
+		self.mock_optimizer = Mock()
+		
+		domain = [{'name': 'var_1', 'type': 'categorical', 'domain': (0, 1)}, {'name': 'var_2', 'type': 'continuous', 'domain': (-5,5), 'dimensionality': 2}]
+		# con_1: if var_1 is 0, var_2_1 must be <= -1
+		# con_2: 3 * (var_2_1 + var_2_2) <= 24
+		constraints = [{'name': 'con_1', 'constraint': '(x[:,0] == 0) * (x[:,1] + 1)'}, 
+						{'name': 'con_2', 'constraint': ' 3 * (x[:,1] + x[:,2]) - 24'}]
+		self.space = Design_space(domain, constraints)
+
+		self.ei_acquisition = AcquisitionEI(self.mock_model, self.space, self.mock_optimizer)
+		self.ei_acquisition._compute_acq = Mock()
+		self.ei_acquisition._compute_acq_withGradients = Mock()
+
+	def test_acquisition_function(self):
+		"""Test that acquisition function does correct constraint(s) check"""
+		
+		y = [1.37, 8.22, 4.2, 0.55, 3.14]
+		self.ei_acquisition._compute_acq.return_value = np.array(y)[:, None]
+		correct_y = [-y[0]] + [0,0] + [-y[3]] + [0]
+		x_unzipped = np.array([[0, 1, 3.3, -3.3], [1, 0, 1.5, 4.7], [0, 1, 4.1, 4.5], [1, 0, -4.1, 4.5], [1, 0, 5, 3]])
+		
+		acquisitions = self.ei_acquisition.acquisition_function(x_unzipped)
+		
+		assert np.isclose(acquisitions, np.array(correct_y)[:, None]).all()
+	
+	def test_acquisition_function_withGradients(self):
+		"""Test that acquisition function does correct constraint(s) check with gradients"""
+
+		y = [1.37, 8.22, 4.2, 0.55, 3.14]
+		y_grad = [.3, .7, -.5, .1, -.02]
+		self.ei_acquisition._compute_acq_withGradients.return_value = np.array(y)[:, None], np.array(y_grad)[:, None]
+		correct_y = [-y[0]] + [0,0] + [-y[3]] + [0]
+		correct_y_grad = [-y_grad[0]] + [0,0] + [-y_grad[3]] + [0]
+		x_unzipped = np.array([[0, 1, 3.3, -3.3], [1, 0, 1.5, 4.7], [0, 1, 4.1, 4.5], [1, 0, -4.1, 4.5], [1, 0, 5, 3]])
+
+		acquisitions, gradients = self.ei_acquisition.acquisition_function_withGradients(x_unzipped)
+
+		assert np.isclose(acquisitions, np.array(correct_y)[:, None]).all()
+		assert np.isclose(gradients, np.array(correct_y_grad)[:, None]).all()


### PR DESCRIPTION
This is a fix for issue #94 
It seems this is a problem primarily if one has categorical variables **AND** either they are part of the constraint(s) formulae _or_ you only have constraints on other variables but some categorical variables are entered into the space list before them.
I have just edited the constraints check to use the zipped inputs so that the correct constraint check is done.

This fix was previously shared in the thread for the issue - [SheffieldML#94](https://github.com/SheffieldML/GPyOpt/issues/94#issuecomment-490955574).

Folarin