### PR TITLE
coloring acquisition plot by the step of the objective evaluation

### DIFF
--- a/GPyOpt/plotting/plots_bo.py
+++ b/GPyOpt/plotting/plots_bo.py
@@ -96,6 +96,10 @@ def plot_acquisition(bounds, input_dim, model, Xdata, Ydata, acquisition_functio
         colors = np.linspace(0, 1, n)
         cmap = plt.cm.Reds
         norm = plt.Normalize(vmin=0, vmax=1)
+        points_var_color = lambda X: plt.scatter(
+            X[:,0], X[:,1], c=colors, label=u'Observations', cmap=cmap, norm=norm)
+        points_one_color = lambda X: plt.plot(
+            X[:,0], X[:,1], 'r.', markersize=10, label=u'Observations')
         X1 = np.linspace(bounds[0][0], bounds[0][1], 200)
         X2 = np.linspace(bounds[1][0], bounds[1][1], 200)
         x1, x2 = np.meshgrid(X1, X2)
@@ -109,11 +113,9 @@ def plot_acquisition(bounds, input_dim, model, Xdata, Ydata, acquisition_functio
         plt.contourf(X1, X2, m.reshape(200,200),100)
         plt.colorbar()
         if color_by_step:
-            plt.scatter(Xdata[:,0], Xdata[:,1], c=colors, label=u'Observations',
-                cmap=cmap, norm=norm)
+            points_var_color(Xdata)
         else:
-            plt.plot(Xdata[:,0], Xdata[:,1], 'r.', markersize=10, label=u'Observations')
-        plt.xlabel(label_x)
+            points_one_color(Xdata)
         plt.ylabel(label_y)
         plt.title('Posterior mean')
         plt.axis((bounds[0][0],bounds[0][1],bounds[1][0],bounds[1][1]))
@@ -122,10 +124,9 @@ def plot_acquisition(bounds, input_dim, model, Xdata, Ydata, acquisition_functio
         plt.contourf(X1, X2, np.sqrt(v.reshape(200,200)),100)
         plt.colorbar()
         if color_by_step:
-            plt.scatter(Xdata[:,0], Xdata[:,1], c=colors, label=u'Observations',
-                cmap=cmap, norm=norm)
+            points_var_color(Xdata)
         else:
-            plt.plot(Xdata[:,0], Xdata[:,1], 'r.', markersize=10, label=u'Observations')
+            points_one_color(Xdata)
         plt.xlabel(label_x)
         plt.ylabel(label_y)
         plt.title('Posterior sd.')

--- a/GPyOpt/plotting/plots_bo.py
+++ b/GPyOpt/plotting/plots_bo.py
@@ -9,7 +9,7 @@ import pylab
 
 
 def plot_acquisition(bounds, input_dim, model, Xdata, Ydata, acquisition_function, suggested_sample,
-                     filename=None, label_x=None, label_y=None):
+                     filename=None, label_x=None, label_y=None, color_by_step=True):
     '''
     Plots of the model and the acquisition function in 1D and 2D examples.
     '''
@@ -92,6 +92,10 @@ def plot_acquisition(bounds, input_dim, model, Xdata, Ydata, acquisition_functio
         if not label_y:
             label_y = 'X2'
 
+        n = Xdata.shape[0]
+        colors = np.linspace(0, 1, n)
+        cmap = plt.cm.Reds
+        norm = plt.Normalize(vmin=0, vmax=1)
         X1 = np.linspace(bounds[0][0], bounds[0][1], 200)
         X2 = np.linspace(bounds[1][0], bounds[1][1], 200)
         x1, x2 = np.meshgrid(X1, X2)
@@ -103,17 +107,25 @@ def plot_acquisition(bounds, input_dim, model, Xdata, Ydata, acquisition_functio
         plt.figure(figsize=(15,5))
         plt.subplot(1, 3, 1)
         plt.contourf(X1, X2, m.reshape(200,200),100)
-        plt.plot(Xdata[:,0], Xdata[:,1], 'r.', markersize=10, label=u'Observations')
         plt.colorbar()
+        if color_by_step:
+            plt.scatter(Xdata[:,0], Xdata[:,1], c=colors, label=u'Observations',
+                cmap=cmap, norm=norm)
+        else:
+            plt.plot(Xdata[:,0], Xdata[:,1], 'r.', markersize=10, label=u'Observations')
         plt.xlabel(label_x)
         plt.ylabel(label_y)
         plt.title('Posterior mean')
         plt.axis((bounds[0][0],bounds[0][1],bounds[1][0],bounds[1][1]))
         ##
         plt.subplot(1, 3, 2)
-        plt.plot(Xdata[:,0], Xdata[:,1], 'r.', markersize=10, label=u'Observations')
         plt.contourf(X1, X2, np.sqrt(v.reshape(200,200)),100)
         plt.colorbar()
+        if color_by_step:
+            plt.scatter(Xdata[:,0], Xdata[:,1], c=colors, label=u'Observations',
+                cmap=cmap, norm=norm)
+        else:
+            plt.plot(Xdata[:,0], Xdata[:,1], 'r.', markersize=10, label=u'Observations')
         plt.xlabel(label_x)
         plt.ylabel(label_y)
         plt.title('Posterior sd.')
@@ -122,7 +134,7 @@ def plot_acquisition(bounds, input_dim, model, Xdata, Ydata, acquisition_functio
         plt.subplot(1, 3, 3)
         plt.contourf(X1, X2, acqu_normalized,100)
         plt.colorbar()
-        plt.plot(suggested_sample[:,0],suggested_sample[:,1],'k.', markersize=10)
+        plt.plot(suggested_sample[:,0],suggested_sample[:,1],'m.', markersize=10)
         plt.xlabel(label_x)
         plt.ylabel(label_y)
         plt.title('Acquisition function')


### PR DESCRIPTION
Previously, all objective function evaluations were colored red identically using `plot_acquisition` in `GPyOpt/plotting/plots_bo.py`. This change adds a boolean argument to the end of the `plot_acquisition()` signature, namely `color_by_step=True`, which colors the objective function evaluations from white to red, as depicted in the plots below.

![acquisition](https://user-images.githubusercontent.com/6068321/74200220-295cd880-4c1b-11ea-94e9-1b646f78e24c.png)

Tested on MacOSX using Python3.7.4 and the 'pdf' backend for matplotlib.
The objective function above is y=inverse.logit(x1+x2).