### PR TITLE
Issue 324 precomputed search space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ docs/_build
 
 # Virtual environments
 venv/
+
+# PyCharm
+.idea

--- a/GPyOpt/core/task/space.py
+++ b/GPyOpt/core/task/space.py
@@ -61,7 +61,7 @@ class Design_space(object):
 
     supported_types = ['continuous', 'discrete', 'bandit','categorical']
 
-    def __init__(self, space, constraints=None, store_noncontinuous = False):
+    def __init__(self, space, constraints=None, store_noncontinuous=False, all_x_values=None):
 
         ## --- Complete and expand attributes
         self.store_noncontinuous = store_noncontinuous
@@ -77,6 +77,9 @@ class Design_space(object):
         self.objective_dimensionality = len(self.space_expanded)
         self.model_input_dims = [v.dimensionality_in_model for v in self.space_expanded]
         self.model_dimensionality = sum(self.model_input_dims)
+
+        # in case the search space is pre-computed and can be passed directly to BO
+        self.all_x_values = all_x_values
 
         # Because of the misspelling API used to expect "constrain" as a key
         # This fixes the API but also supports the old form

--- a/GPyOpt/experiment_design/__init__.py
+++ b/GPyOpt/experiment_design/__init__.py
@@ -5,7 +5,6 @@ from .random_design import RandomDesign
 from .sobol_design import SobolDesign
 
 def initial_design(design_name, space, init_points_count):
-    design = None
     if design_name == 'random':
         design = RandomDesign(space)
     elif design_name == 'sobol':

--- a/GPyOpt/methods/bayesian_optimization.py
+++ b/GPyOpt/methods/bayesian_optimization.py
@@ -91,7 +91,10 @@ class BayesianOptimization(BO):
         # --- CHOOSE design space
         self.constraints = constraints
         self.domain = domain
-        self.space = Design_space(self.domain, self.constraints)
+        if "all_x_values" in kwargs:
+            self.space = Design_space(self.domain, self.constraints, all_x_values=kwargs["all_x_values"])
+        else:
+            self.space = Design_space(self.domain, self.constraints)
 
         # --- CHOOSE objective function
         self.maximize = maximize

--- a/GPyOpt/optimization/anchor_points_generator.py
+++ b/GPyOpt/optimization/anchor_points_generator.py
@@ -27,7 +27,7 @@ class AnchorPointsGenerator(object):
         ## --- We use the context handler to remove duplicates only over the non-context variables
         if context_manager and not self.space._has_bandit():
             space_configuration_without_context = [self.space.config_space_expanded[idx] for idx in context_manager.nocontext_index_obj]
-            space = Design_space(space_configuration_without_context, context_manager.space.constraints)
+            space = Design_space(space_configuration_without_context, context_manager.space.constraints, all_x_values=self.space.all_x_values)
             add_context = lambda x : context_manager._expand_vector(x)
         else:
             space = self.space

--- a/GPyOpt/testing/experiment_design_tests/random_design_test.py
+++ b/GPyOpt/testing/experiment_design_tests/random_design_test.py
@@ -1,0 +1,53 @@
+import unittest
+
+import numpy as np
+
+from GPyOpt import experiment_design
+from GPyOpt.core.task.space import Design_space
+
+
+class TestRandomDesign(unittest.TestCase):
+    def test_random_design_with_all_x_values(self):
+        domain = [1, 2]
+        space = [{'name': 'var_0',
+                  'type': 'discrete',
+                  'domain': [1, 2],
+                  'dimensionality': 3}]
+
+        # # d_n <= d_n-1 -> d_n - d_n-1 <= 0
+        constraints = [{'name': 'const_' + str(i),
+                        'constraint': "x[:, " + str(i + 1) + "] - x[:, " + str(i) + "]"}
+                       for i in range(0, 2)]  # x1-x0<=0, x2-x1<=0
+
+        all_x_values = np.asarray([[2, 2, 2],
+                                   [2, 2, 1],
+                                   [2, 1, 1],
+                                   [1, 1, 1]])
+
+        design_space = Design_space(space, constraints=constraints, all_x_values=all_x_values)
+
+        X = experiment_design.initial_design(design_name="random", space=design_space, init_points_count=4)
+        self.assertEqual(X.shape[0], 4)
+        self.assertEqual(X.shape[1], 3)
+        self.assertEqual(np.count_nonzero(X == 2), 6)
+        self.assertEqual(np.count_nonzero(X == 1), 6)
+        X_unique = np.unique(X).tolist()
+        self.assertEqual(domain, X_unique)
+
+        X = experiment_design.initial_design(design_name="random", space=design_space, init_points_count=1000)
+        self.assertEqual(X.shape[0], 4)
+        self.assertEqual(X.shape[1], 3)
+        self.assertEqual(np.count_nonzero(X == 2), 6)
+        self.assertEqual(np.count_nonzero(X == 1), 6)
+        X_unique = np.unique(X).tolist()
+        self.assertEqual(domain, X_unique)
+
+        X = experiment_design.initial_design(design_name="random", space=design_space, init_points_count=0)
+        self.assertEqual(X.shape[0], 0)
+        self.assertEqual(X.shape[1], 3)
+
+        X = experiment_design.initial_design(design_name="random", space=design_space, init_points_count=2)
+        self.assertEqual(X.shape[0], 2)
+        self.assertEqual(X.shape[1], 3)
+        X_unique = np.unique(X).tolist()
+        self.assertEqual(domain, X_unique)


### PR DESCRIPTION
https://github.com/SheffieldML/GPyOpt/pull/342 - I accidentally closed that PR without any option to re-open, sorry.

So we have a miscommunication here. This is not a feature, this is actually a bug fix!
Why?
- the computations hang in anchor point creation in case I use constraints option; the issue is in while loop in get_samples_with_constraints method in GPyOpt/experiment_design/random_design.py when used in anchor points generator for aquisition function.
- moreover I cannot bypass that issue in methods as: 1. I cannot use modular option (I use calls "step by step", not in the loop); 2. exposed initial experimental design option in methods (both modular and BO) means just the way to sample initially objective function, which is not a problem.